### PR TITLE
add data attribute to MongoenginePartialMixin() to match what is done…

### DIFF
--- a/social_mongoengine/storage.py
+++ b/social_mongoengine/storage.py
@@ -178,6 +178,7 @@ class MongoengineCodeMixin(CodeMixin):
 
 class MongoenginePartialMixin(PartialMixin):
     token = StringField(max_length=32)
+    data = DictField()
     extra_data = DictField()
     next_step = IntField()
     backend = StringField(max_length=32)


### PR DESCRIPTION
add data attribute to MongoenginePartialMixin() to match what is done for social_django/models

this fixes https://github.com/python-social-auth/social-core/issues/57